### PR TITLE
CiviRules condition

### DIFF
--- a/CRM/Points/CivirulesCondition.mgd.php
+++ b/CRM/Points/CivirulesCondition.mgd.php
@@ -1,0 +1,17 @@
+<?php
+
+if (_civipoints_is_civirules_installed()) {
+  return array(
+    0 => array(
+      'name'   => 'Civirules:Condition.Points',
+      'entity' => 'CiviRuleCondition',
+      'params' => array(
+        'version'    => 3,
+        'name'       => 'civipoints_getsum',
+        'label'      => 'Contact has points',
+        'class_name' => 'CRM_Points_CivirulesCondition',
+        'is_active'  => 1,
+      ),
+    ),
+  );
+}

--- a/CRM/Points/CivirulesCondition.php
+++ b/CRM/Points/CivirulesCondition.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class for CiviRules condition of CiviPoints received
+ */
+class CRM_Points_CivirulesCondition extends CRM_CivirulesConditions_Generic_ValueComparison {
+  /**
+   * Returns the number of points the contact has
+   *
+   * TODO: Only checks points as at the time of the check,
+   * only checks the default points type
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   * @return boolean|int FALSE on error, or an integer sum of points in effect
+   */
+  protected function getFieldValue(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    $cid = $triggerData->getContactId();
+    $points_type_id = civicrm_api('OptionValue', 'getvalue', array(
+      'version'           => 3,
+      'option_group_name' => 'points_type',
+      'is_default'        => 1,
+      'return'            => 'value',
+    ));
+
+    $points = civicrm_api('Points', 'getsum', array(
+      'version'        => 3,
+      'contact_id'     => $cid,
+      'points_type_id' => $points_type_id,
+    ));
+
+    if (civicrm_error($points)) {
+      return FALSE;
+    }
+    elseif (empty($points)) {
+      // As we may get NULL if the contact has no points grants in effect
+      return 0;
+    }
+    else {
+      return $points;
+    }
+  }
+
+  /**
+   * Returns user-friendly text explaining the condition for the
+   * 'CiviRules Update Rule' screen,
+   * eg. 'Contact has at least 5 points' rather than '>= 5'
+   *
+   * @return string
+   */
+  public function userFriendlyConditionParams() {
+    switch ($this->getOperator()) {
+      case '=':
+        $label = 'Contact has exactly %1 points';
+        break;
+      case '>':
+        $label = 'Contact has more than %1 points';
+        break;
+      case '<':
+        $label = 'Contact has less than %1 points';
+        break;
+      case '>=':
+        $label = 'Contact has at least %1 points';
+        break;
+      case '<=':
+        $label = 'Contact has at most %1 points';
+        break;
+      case '!=':
+        $label = 'Contact does not have exactly %1 points';
+        break;
+      default:
+        return '';
+    }
+    return ts($label, array(1 => $this->getComparisonValue()));
+  }
+
+  /**
+   * Returns a list of available comparison operators and explanations,
+   * for the 'CiviRules Edit Condition parameters' screen.
+   *
+   * @return array
+   */
+  public function getOperators() {
+    return array(
+      '='  => ts('Exactly this many points'),
+      '!=' => ts('Not this many points'),
+      '>'  => ts('More than this many points'),
+      '<'  => ts('Less than this many points'),
+      '>=' => ts('At least this many points'),
+      '<=' => ts('At most this many points'),
+    );
+  }
+}

--- a/CRM/Points/CivirulesCondition.php
+++ b/CRM/Points/CivirulesCondition.php
@@ -7,20 +7,12 @@ class CRM_Points_CivirulesCondition extends CRM_CivirulesConditions_Generic_Valu
   /**
    * Returns the number of points the contact has
    *
-   * TODO: Only checks points as at the time of the check,
-   * only checks the default points type
-   *
    * @param CRM_Civirules_TriggerData_TriggerData $triggerData
    * @return boolean|int FALSE on error, or an integer sum of points in effect
    */
   protected function getFieldValue(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $cid = $triggerData->getContactId();
-    $points_type_id = civicrm_api('OptionValue', 'getvalue', array(
-      'version'           => 3,
-      'option_group_name' => 'points_type',
-      'is_default'        => 1,
-      'return'            => 'value',
-    ));
+    $points_type_id = $this->conditionParams['points_type_id'];
 
     $points = civicrm_api('Points', 'getsum', array(
       'version'        => 3,
@@ -43,34 +35,45 @@ class CRM_Points_CivirulesCondition extends CRM_CivirulesConditions_Generic_Valu
   /**
    * Returns user-friendly text explaining the condition for the
    * 'CiviRules Update Rule' screen,
-   * eg. 'Contact has at least 5 points' rather than '>= 5'
+   * eg. 'Contact has at least 5 Default Type points' rather than '>= 5'
    *
    * @return string
    */
   public function userFriendlyConditionParams() {
     switch ($this->getOperator()) {
       case '=':
-        $label = 'Contact has exactly %1 points';
+        $label = 'Contact has exactly %1 %2 points';
         break;
       case '>':
-        $label = 'Contact has more than %1 points';
+        $label = 'Contact has more than %1 %2 points';
         break;
       case '<':
-        $label = 'Contact has less than %1 points';
+        $label = 'Contact has less than %1 %2 points';
         break;
       case '>=':
-        $label = 'Contact has at least %1 points';
+        $label = 'Contact has at least %1 %2 points';
         break;
       case '<=':
-        $label = 'Contact has at most %1 points';
+        $label = 'Contact has at most %1 %2 points';
         break;
       case '!=':
-        $label = 'Contact does not have exactly %1 points';
+        $label = 'Contact does not have exactly %1 %2 points';
         break;
       default:
         return '';
     }
-    return ts($label, array(1 => $this->getComparisonValue()));
+
+    $type = civicrm_api('OptionValue', 'getvalue', array(
+      'version'           => 3,
+      'option_group_name' => 'points_type',
+      'value'             => $this->conditionParams['points_type_id'],
+      'return'            => 'label',
+    ));
+
+    return ts($label, array(
+      1 => $this->getComparisonValue(),
+      2 => $type,
+    ));
   }
 
   /**
@@ -87,6 +90,20 @@ class CRM_Points_CivirulesCondition extends CRM_CivirulesConditions_Generic_Valu
       '<'  => ts('Less than this many points'),
       '>=' => ts('At least this many points'),
       '<=' => ts('At most this many points'),
+    );
+  }
+
+  /**
+   * Returns the URL of the form to add extra parameters to the condition,
+   * eg. the points type we're interested in
+   *
+   * @param int $ruleConditionId
+   * @return string
+   */
+  public function getExtraDataInputUrl($ruleConditionId) {
+    return CRM_Utils_System::url(
+      'civicrm/civirule/form/condition/points',
+      array('rule_condition_id' => $ruleConditionId)
     );
   }
 }

--- a/CRM/Points/Form/CivirulesCondition.php
+++ b/CRM/Points/Form/CivirulesCondition.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once 'CRM/Core/Form.php';
+
+/**
+ * Form controller class
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_Points_Form_CivirulesCondition extends CRM_CivirulesConditions_Form_ValueComparison {
+  /**
+   * Overridden to add the Points Type field to the value comparison condition
+   */
+  public function buildQuickForm() {
+    parent::buildQuickForm();
+    $this->add('select', 'points_type_id', ts('Points Type'), CRM_Core_OptionGroup::values('points_type'), TRUE);
+  }
+
+  /**
+   * If editing an existing condition, load existing data into the form.
+   * If not, use the default points type option.
+   *
+   * @return array
+   */
+  public function setDefaultValues() {
+    // Load data from existing condition
+    $data = array();
+    $defaultValues = parent::setDefaultValues();
+    if ($this->ruleCondition->find(true)) {
+      $data = unserialize($this->ruleCondition->condition_params);
+    }
+
+    if (empty($data['points_type_id'])) {
+      // Get default points type
+      $defaultValues['points_type_id'] = civicrm_api('OptionValue', 'getvalue', array(
+        'version'           => 3,
+        'option_group_name' => 'points_type',
+        'is_default'        => 1,
+        'return'            => 'value',
+      ));
+    }
+    else {
+      $defaultValues['points_type_id'] = $data['points_type_id'];
+    }
+    return $defaultValues;
+  }
+
+  /**
+   * Save the value of the points type field. The rest is left to the parent form.
+   */
+  public function postProcess() {
+    $data = unserialize($this->ruleCondition->condition_params);
+    $data['points_type_id'] = $this->_submitValues['points_type_id'];
+    $this->ruleCondition->condition_params = serialize($data);
+    $this->ruleCondition->save();
+    parent::postProcess();
+  }
+}

--- a/templates/CRM/Points/Form/CivirulesCondition.tpl
+++ b/templates/CRM/Points/Form/CivirulesCondition.tpl
@@ -1,0 +1,59 @@
+<h3>{$ruleConditionHeader}</h3>
+<div class="crm-block crm-form-block crm-civirule-rule_condition-block-points-getsum">
+    <div class="crm-section">
+        <div class="label">{$form.points_type_id.label}</div>
+        <div class="content">{$form.points_type_id.html}</div>
+        <div class="clear"></div>
+    </div>
+    <div class="crm-section">
+        <div class="label">{$form.operator.label}</div>
+        <div class="content">{$form.operator.html}</div>
+        <div class="clear"></div>
+    </div>
+    <div class="crm-section" id="value_parent">
+        <div class="label">{$form.value.label}</div>
+        <div class="content">
+            {$form.value.html}
+            <select id="value_options" class="hiddenElement">
+
+            </select>
+        </div>
+        <div class="clear"></div>
+    </div>
+    <div class="crm-section" id="multi_value_parent">
+        <div class="label">{$form.multi_value.label}</div>
+        <div class="content textarea">
+            {$form.multi_value.html}
+            <p class="description">{ts}Seperate each value on a new line{/ts}</p>
+        </div>
+        <div id="multi_value_options" class="hiddenElement content">
+
+        </div>
+        <div class="clear"></div>
+    </div>
+</div>
+<div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>
+{include file="CRM/CivirulesConditions/Form/ValueComparisonJs.tpl"}
+
+{literal}
+<script type="text/javascript">
+    var options = new Array();
+    {/literal}
+    {if ($field_options)}
+        {foreach from=$field_options item=value key=key}
+    {literal}options[options.length] = {'key': key, 'value': value};{/literal}
+        {/foreach}
+    {/if}
+    {if ($is_field_option_multiple)}
+        var multiple = true;
+    {else}
+        var multiple = false;
+    {/if}
+    {literal}
+    cj(function() {
+        CRM_civirules_conidtion_form_updateOptionValues(options, multiple);
+    });
+</script>
+{/literal}

--- a/xml/Menu/civipoints.xml
+++ b/xml/Menu/civipoints.xml
@@ -24,4 +24,10 @@
     <title>CiviPoints API (CiviRules action)</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/civirule/form/condition/points</path>
+    <page_callback>CRM_Points_Form_CivirulesCondition</page_callback>
+    <title>CiviPoints (CiviRules condition)</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
Allow a CiviRule to say something like: "When W happens, _if the contact has at least X points of type Y_, do Z." Extends the generic value comparison condition in CiviRules, partly based on things like that, age comparison and field value comparison.
