### PR TITLE
Add fallback to detect CiviRules

### DIFF
--- a/civipoints.civix.php
+++ b/civipoints.civix.php
@@ -173,6 +173,7 @@ function _civipoints_civix_civicrm_managed(&$entities) {
   $mgdFiles = _civipoints_civix_find_files(__DIR__, '*.mgd.php');
   foreach ($mgdFiles as $file) {
     $es = include $file;
+    if (!is_array($es)) continue;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = 'uk.org.futurefirst.networks.civipoints';

--- a/civipoints.php
+++ b/civipoints.php
@@ -296,7 +296,13 @@ function _civipoints_is_civirules_installed() {
         $installed = TRUE;
       }
     }
-    return $installed;
+    if ($installed) return $installed;
+
+    // CiviRules doesn't appear in the list of extensions above, so check directly.
+    $select = CRM_Utils_SQL_Select::from('civicrm_extension')
+      ->where("full_name = '!ext'", array('!ext' =>'org.civicoop.civirules'))
+      ->where('is_active = !installed', array('!installed' => TRUE));
+    return (bool) count($select->execute()->fetchAll());
   }
   catch (Exception $e) {
     return FALSE;


### PR DESCRIPTION
Upon enabling the CiviPoint extension, I received the following warning twice:

> Warning: Invalid argument supplied for foreach() in _civipoints_civix_civicrm_managed() (line 176 of /path/to/civicrm/extensions/uk.org.futurefirst.networks.civipoints/civipoints.civix.php).

I believe this warning is due to a couple managed entities ([here](https://github.com/futurefirst/uk.org.futurefirst.networks.civipoints/blob/master/CRM/Points/CivirulesAction.mgd.php) and [here](https://github.com/futurefirst/uk.org.futurefirst.networks.civipoints/blob/master/CRM/Points/CivirulesCondition.mgd.php). The intention appears to be that these entities are only loaded if CiviRules has been installed.

First off, the [function](https://github.com/futurefirst/uk.org.futurefirst.networks.civipoints/blob/master/civipoints.civix.php#L172) that loads the managed entities assumes the included files will result in an array. If CiviRules is not installed, it should result in NULL, hence the warnings, as the code tries to iterate over the non-existent array. Returning an array in the "mgd.php" filess may result in mis-configured entities (since no settings will have been loaded. On the other hand, _civipoints_civix_civicrm_managed() is in an auto-generated file. So altering it may result in it being overwritten at some point.

I believe that the proper long-term fix here is to alter how Civix generates this function, to allow for empty return values, when dependent extensions are not present. In the short term, adding an `is_array()` check should resolve the warnings.

Secondly, I had enabled CiviRules previous to enabling this extension, as per the docs. So, the function that's checking for CiviRules being enabled is suspect, at this point, too. It appears that CiviRules isn't returned in the list of extensions from the API call.

Perhaps this is intentional on the part of CiviRules. But if not, it should be fixed upstream. For now, I've added a fallback method to query the database directly.