### PR TITLE
CiviRule fails with anonymous user (e.g. online donation)

### DIFF
--- a/api/v3/Points.php
+++ b/api/v3/Points.php
@@ -20,7 +20,6 @@ function _civicrm_api3_points_create_spec(&$spec) {
 
   $spec['grantor_contact_id']['title']        = ts('Granting Contact');
   $spec['grantor_contact_id']['api.default']  = $cid;
-  $spec['grantor_contact_id']['api.required'] = 1;
 
   $spec['points']['title']                    = ts('Points Granted/Removed');
   $spec['points']['api.required']             = 1;


### PR DESCRIPTION
I had a CiviRule set up to grant a point to anyone who makes a contribution.

Unfortunately, this caused an error because the CiviRule doesn't specify the `grantor_contact_id` - it relies on using the ID of the logged-in user.  Which, for a typical online contribution, is no one.

However, I looked at the rest of the code and the database structure and saw no reason for the grantor to be a required field - and in fact if you delete a grantor, the database will set the grantor id to `NULL`.